### PR TITLE
Feat: Update switch season edge server, dashboard backend

### DIFF
--- a/dashboard_backend/src/api/dto/dashboard.py
+++ b/dashboard_backend/src/api/dto/dashboard.py
@@ -16,6 +16,11 @@ class UpdateDeviceState(BaseModel):
     state: bool
 
 
+class DeviceModel(BaseModel):
+    id: int = Field(..., ge=0, lt=7, description="Device ID (0-4)")
+    state: bool
+
+
 class UpdateSettings(BaseModel):
     """
     tolerance: "",

--- a/dashboard_backend/src/api/routers/dashboard_router.py
+++ b/dashboard_backend/src/api/routers/dashboard_router.py
@@ -27,11 +27,16 @@ def get_edge_server():
     return EdgeServer()
 
 
+def get_dashboard_service():
+    return DashboardService()
+
+
 @router.get("/")
 def dashboard_data(
     request: Request,
     current_user: Annotated[UserToken, Security(get_current_user)],
     edge_server: Annotated[EdgeServer, Security(get_edge_server)],
+    dashboard_service: Annotated[DashboardService, Security(get_dashboard_service)],
 ):
     data = dashboard_service.get_data()
     return JSONResponse(content=data)
@@ -43,8 +48,13 @@ def update_state(
     current_user: Annotated[UserToken, Security(get_current_user)],
     edge_server: Annotated[EdgeServer, Security(get_edge_server)],
 ):
-    edge_server.update_device_state(id=data.id, state=data.state)
-    return JSONResponse(content={"message": "Updated state successfully"})
+    try:
+        edge_server.update_device_state(id=data.id, state=data.state)
+        return JSONResponse(content={"message": "Updated state successfully"})
+    except ConnectToEdgeServerError:
+        return JSONResponse(
+            content={"detail": "Could not connect to edge server"}, status_code=403
+        )
 
 
 @router.get("/download_log")
@@ -183,11 +193,8 @@ async def boiler_set_setpoint(
 async def switch_season(
     data: SwitchSeason,
     current_user: Annotated[UserToken, Security(get_current_user)],
+    dashboard_service: Annotated[DashboardService, Security(get_dashboard_service)],
+    edge_server: Annotated[EdgeServer, Security(get_edge_server)],
 ):
-    try:
-        result = dashboard_service.switch_season_mode(data.season_value)
-        return JSONResponse(content=result, status_code=200)
-    except Exception as e:
-        return JSONResponse(
-            content={"message": str(e), "status": "error"}, status_code=400
-        )
+    result = dashboard_service.switch_season_mode(data.season_value)
+    return JSONResponse(content=result, status_code=200)

--- a/dashboard_backend/src/api/routers/dashboard_router.py
+++ b/dashboard_backend/src/api/routers/dashboard_router.py
@@ -47,14 +47,10 @@ def update_state(
     data: UpdateDeviceState,
     current_user: Annotated[UserToken, Security(get_current_user)],
     edge_server: Annotated[EdgeServer, Security(get_edge_server)],
+    dashboard_service: Annotated[DashboardService, Security(get_dashboard_service)],
 ):
-    try:
-        edge_server.update_device_state(id=data.id, state=data.state)
-        return JSONResponse(content={"message": "Updated state successfully"})
-    except ConnectToEdgeServerError:
-        return JSONResponse(
-            content={"detail": "Could not connect to edge server"}, status_code=403
-        )
+    data = dashboard_service.update_device_state(data)
+    return JSONResponse(content=data)
 
 
 @router.get("/download_log")

--- a/dashboard_backend/src/core/repositories/boiler_repository.py
+++ b/dashboard_backend/src/core/repositories/boiler_repository.py
@@ -1,0 +1,32 @@
+from datetime import datetime
+
+from src.core.configs.database import session_scope
+from src.core.models import Boiler
+from src.core.repositories.setting_repository import SettingRepository
+
+
+class BoilerRepository:
+    def __init__(self):
+        self.timestamp = datetime.now()
+        self.setting = SettingRepository()
+
+    def _get_property_from_db(self, param):
+        param = getattr(Boiler, param)
+        with session_scope() as session:
+            (value,) = session.query(param).first()
+        return value
+
+    def _update_property_in_db(self, param, value):
+        param = getattr(Boiler, param)
+        with session_scope() as session:
+            session.query(Boiler).filter(Boiler.id == 1).update({param: value})
+
+    def set_status(self, status: int):
+        self._update_property_in_db("status", status)
+        self._update_property_in_db("switched_timestamp", self.timestamp)
+
+    def get_status(self) -> int:
+        return self._get_property_from_db("status")
+
+    def get_unlock_timestamp(self):
+        return self._get_property_from_db("switched_timestamp")

--- a/dashboard_backend/src/core/repositories/chiller_repository.py
+++ b/dashboard_backend/src/core/repositories/chiller_repository.py
@@ -1,0 +1,45 @@
+from datetime import datetime
+
+from src.core import models
+from src.core.configs.database import session_scope
+from src.core.repositories.setting_repository import SettingRepository
+
+
+class ChillerRepository:
+    def __init__(self):
+        self.timestamp = datetime.now()
+        self.setting = SettingRepository()
+
+    def _update_value_in_db(self, chiller_name: str, **kwargs):
+        model_class = getattr(models, chiller_name)
+        to_backup = kwargs.pop("to_backup", False)
+        with session_scope() as session:
+            property_ = (
+                session.query(model_class)
+                .filter(model_class.backup == to_backup)
+                .first()
+            )
+            for key, value in kwargs.items():
+                setattr(property_, key, value)
+
+    def _get_property_from_db(self, chiller_name: str, *args, **kwargs):
+        device = getattr(models, chiller_name)
+        from_backup = kwargs.pop("from_backup", False)
+        with session_scope() as session:
+            instance = (
+                session.query(device).filter(device.backup == from_backup).first()
+            )
+            result = [getattr(instance, arg) for arg in args]
+        if len(result) == 1:
+            result = result[0]
+        return result
+
+    def set_chiller_status(self, chiller_name: str, status: int):
+        self._update_value_in_db(chiller_name, "status", status)
+        self._update_value_in_db(chiller_name, "switched_timestamp", self.timestamp)
+
+    def get_chiller_status(self, chiller_name: str) -> int:
+        return self._get_property_from_db(chiller_name, "status")
+
+    def get_unlock_timestamp(self, chiller_name: str):
+        return self._get_property_from_db(chiller_name, "switched_timestamp")

--- a/dashboard_backend/src/core/repositories/device_repository.py
+++ b/dashboard_backend/src/core/repositories/device_repository.py
@@ -1,0 +1,31 @@
+from src.core import models
+from src.core.configs.database import session_scope
+
+
+class DeviceRepository:
+    def __init__(self, table_class_name):
+        self.table_class_name = table_class_name
+
+    def _update_value_in_db(self, **kwargs):
+        model_class = getattr(models, self.table_class_name)
+        to_backup = kwargs.pop("to_backup", False)
+        with session_scope() as session:
+            property_ = (
+                session.query(model_class)
+                .filter(model_class.backup == to_backup)
+                .first()
+            )
+            for key, value in kwargs.items():
+                setattr(property_, key, value)
+
+    def _get_property_from_db(self, *args, **kwargs):
+        device = getattr(models, self.table_class_name)
+        from_backup = kwargs.pop("from_backup", False)
+        with session_scope() as session:
+            instance = (
+                session.query(device).filter(device.backup == from_backup).first()
+            )
+            result = [getattr(instance, arg) for arg in args]
+        if len(result) == 1:
+            result = result[0]
+        return result

--- a/dashboard_backend/src/core/repositories/history_repository.py
+++ b/dashboard_backend/src/core/repositories/history_repository.py
@@ -49,7 +49,7 @@ class HistoryRepository:
             (value,) = session.query(param).first()
         return value
 
-    def _update_property(self, param, value):
+    def _update_property_in_db(self, param, value):
         param = getattr(Settings, param)
         with session_scope() as session:
             session.query(Settings).filter(Settings.id == 1).update({param: value})

--- a/dashboard_backend/src/core/repositories/setting_repository.py
+++ b/dashboard_backend/src/core/repositories/setting_repository.py
@@ -22,7 +22,7 @@ class SettingRepository:
             (value,) = session.query(param).first()
         return value
 
-    def _update_property(self, param, value):
+    def _update_property_in_db(self, param, value):
         param = getattr(Settings, param)
         with session_scope() as session:
             session.query(Settings).filter(Settings.id == 1).update({param: value})

--- a/dashboard_backend/src/core/services/boiler.py
+++ b/dashboard_backend/src/core/services/boiler.py
@@ -1,15 +1,16 @@
 from src.core.repositories.history_repository import HistoryRepository
 from src.core.repositories.setting_repository import SettingRepository
+from src.core.services.device import Device
 from src.core.utils.constant import Relay
 
 
-class Boiler:
+class Boiler(Device):
     TYPE = "boiler"
 
     def __init__(self):
+        super().__init__("Boiler")
         self.number = 0
-        self.relay_number = Relay.BOILER
-        self.table_class_name = "Boiler"
+        self.relay_number = Relay.BOILER.value
         self.history_repository = HistoryRepository()
         self.setting_repository = SettingRepository()
 

--- a/dashboard_backend/src/core/services/chiller.py
+++ b/dashboard_backend/src/core/services/chiller.py
@@ -1,13 +1,23 @@
+from src.core.repositories.history_repository import HistoryRepository
+from src.core.repositories.setting_repository import SettingRepository
+from src.core.services.device import Device
 from src.core.utils.constant import Relay
 
 
-class Chiller:
+class Chiller(Device):
     TYPE = "chiller"
 
     def __init__(self, number):
         if number not in range(1, 5):
             raise ValueError("Chiller number must be in range from 1 to 4")
-        else:
-            self.number = number
-            self.relay_number = Relay["CHILLER{}".format(number)]
-            self.table_class_name = "Chiller{}".format(number)
+
+        self.number = number
+        self.relay_number = Relay[f"CHILLER{number}"]
+        self.table_class_name = f"Chiller{number}"
+        self.history_repository = HistoryRepository()
+        self.setting_repository = SettingRepository()
+        super().__init__(table_class_name=self.table_class_name)
+
+    @property
+    def setpoint(self):
+        return self.setting_repository._get_property_from_db("setpoint")

--- a/dashboard_backend/src/core/services/chronos.py
+++ b/dashboard_backend/src/core/services/chronos.py
@@ -1,6 +1,7 @@
 from datetime import UTC, datetime, timedelta
 
 import requests
+from apscheduler.schedulers.asyncio import AsyncIOScheduler
 from apscheduler.schedulers.background import BackgroundScheduler
 from sqlalchemy import desc
 from sqlalchemy.sql import func
@@ -15,11 +16,17 @@ from src.core.services.edge_server import EdgeServer
 from src.core.services.valve import Valve
 from src.core.utils.constant import (
     EFFICIENCY_HOUR,
-    SUMMER,
+    MANUAL_AUTO,
+    MANUAL_OFF,
+    MANUAL_ON,
+    OFF,
+    ON,
     WEATHER_HEADERS,
     WEATHER_URL,
-    WINTER,
+    Mode,
 )
+
+scheduler = AsyncIOScheduler()
 
 
 class Chronos(object):
@@ -39,6 +46,7 @@ class Chronos(object):
             self.chiller4,
         )
         self.valves = (self.winter_valve, self.summer_valve)
+
         self._outside_temp = None
         self._wind_speed = None
         self._baseline_setpoint = None
@@ -47,10 +55,19 @@ class Chronos(object):
         self._water_out_temp = None
         self._return_temp = None
         self.scheduler = BackgroundScheduler()
+        self.scheduler.start()
         #
         self.history_repository = HistoryRepository()
         self.setting_repository = SettingRepository()
         self.edge_server = EdgeServer()
+
+    @property
+    def mode(self):
+        return self.setting_repository._get_property_from_db("mode")
+
+    @mode.setter
+    def mode(self, mode: int):
+        self.setting_repository._update_property_in_db("mode", mode)
 
     def get_data_from_web(self):
         logger.debug("Retrieve data from web.")
@@ -91,17 +108,13 @@ class Chronos(object):
         return self._wind_speed or self.get_data_from_web()["wind_speed"]
 
     @property
-    def mode(self):
-        return self.setting_repository._get_property_from_db("mode")
-
-    @property
     def cascade_fire_rate_avg(self):
         timespan = datetime.now() - timedelta(hours=EFFICIENCY_HOUR)
         with session_scope() as session:
             result = (
                 session.query(History.cascade_fire_rate)
                 .order_by(desc(History.id))
-                .filter(History.mode == WINTER, History.timestamp > timespan)
+                .filter(History.mode == Mode.WINTER.value, History.timestamp > timespan)
                 .subquery()
             )
             (average_cascade_fire_rate,) = session.query(
@@ -109,11 +122,31 @@ class Chronos(object):
             ).first()
         return average_cascade_fire_rate or 0
 
+    @property
+    def mode_switch_lockout_time(self):
+        return self.setting_repository._get_property_from_db("mode_switch_lockout_time")
+
+    @mode_switch_lockout_time.setter
+    def mode_switch_lockout_time(self, mode_switch_lockout_time):
+        self.setting_repository._update_property_in_db(
+            "mode_switch_lockout_time", mode_switch_lockout_time
+        )
+
+    @property
+    def mode_switch_timestamp(self):
+        return self.setting_repository._get_property_from_db("mode_switch_timestamp")
+
+    @mode_switch_timestamp.setter
+    def mode_switch_timestamp(self, mode_switch_timestamp):
+        self.setting_repository._update_property_in_db(
+            "mode_switch_timestamp", mode_switch_timestamp
+        )
+
     def create_update_history(self):
         edge_server_data = self.edge_server.get_data()
         sensors = edge_server_data["sensors"]
         mode = self.mode
-        if mode in (WINTER, SUMMER):
+        if mode in (Mode.WINTER.value, Mode.SUMMER.value):
             with session_scope() as session:
                 parameters = History(
                     timestamp=datetime.now(UTC),
@@ -123,3 +156,87 @@ class Chronos(object):
                     mode=mode,
                 )
                 session.add(parameters)
+
+    def _switch_devices(self):
+        for device in self.devices:
+            if device.manual_override == MANUAL_ON:
+                device.turn_on(relay_only=True)
+            elif device.manual_override == MANUAL_OFF:
+                device.turn_off(relay_only=True)
+            elif device.manual_override == MANUAL_AUTO:
+                if device.status == ON:
+                    device.turn_on(relay_only=True)
+                elif device.status == OFF:
+                    device.turn_off(relay_only=True)
+
+    def _save_devices_states(self, mode):
+        if mode == Mode.SWITCHING_TO_SUMMER.value:
+            self.boiler.save_status()
+        elif mode == Mode.SWITCHING_TO_WINTER.value:
+            for chiller in self.devices[1:]:
+                chiller.save_status()
+
+    def _restore_devices_states(self, mode: Mode):
+        if mode == Mode.SWITCHING_TO_SUMMER.value:
+            self.boiler.restore_status()
+        elif mode == Mode.SWITCHING_TO_WINTER.value:
+            for chiller in self.devices[1:]:
+                chiller.restore_status()
+
+    def turn_off_devices(self, with_valves=False, relay_only=False):
+        if relay_only:
+            for device in self.devices:
+                device.turn_off(relay_only=relay_only)
+        else:
+            for device in self.devices:
+                device.manual_override = MANUAL_OFF
+            if with_valves:
+                self.winter_valve.turn_off()
+                self.summer_valve.turn_off()
+
+    def _switch_season(self, mode: int):
+        if mode == Mode.WAITING_SWITCH_TO_SUMMER.value:
+            logger.debug("Switching to summer mode")
+            self.mode = Mode.WAITING_SWITCH_TO_SUMMER.value
+            self.mode_switch_timestamp = datetime.now()
+            self._save_devices_states(mode)
+            self.turn_off_devices()
+            self.summer_valve.turn_on()
+            self.winter_valve.turn_off()
+
+            self.scheduler.add_job(
+                self._switch_season,
+                "date",
+                run_date=datetime.now()
+                + timedelta(minutes=self.mode_switch_lockout_time),
+                args=[Mode.SWITCHING_TO_SUMMER.value],
+            )
+
+        elif mode == Mode.WAITING_SWITCH_TO_WINTER.value:
+            logger.debug("Switching to winter mode")
+            self.mode = Mode.WAITING_SWITCH_TO_WINTER.value
+            self.mode_switch_timestamp = datetime.now()
+            self._save_devices_states(mode)
+            self.turn_off_devices()
+            self.summer_valve.turn_off()
+            self.winter_valve.turn_on()
+
+            self.scheduler.add_job(
+                self._switch_season,
+                "date",
+                run_date=datetime.now()
+                + timedelta(minutes=self.mode_switch_lockout_time),
+                args=[Mode.SWITCHING_TO_WINTER.value],
+            )
+
+        elif mode == Mode.SWITCHING_TO_WINTER.value:
+            logger.debug("Switched to winter mode")
+            self._restore_devices_states(mode)
+            self._switch_devices()
+            self.mode = Mode.WINTER.value
+
+        elif mode == Mode.SWITCHING_TO_SUMMER.value:
+            logger.debug("Switched to summer mode")
+            self._restore_devices_states(mode)
+            self._switch_devices()
+            self.mode = Mode.SUMMER.value

--- a/dashboard_backend/src/core/services/device.py
+++ b/dashboard_backend/src/core/services/device.py
@@ -1,0 +1,107 @@
+from datetime import datetime
+
+from src.core.repositories.device_repository import DeviceRepository
+from src.core.services.edge_server import EdgeServer
+from src.core.utils.constant import MANUAL_AUTO, MANUAL_OFF, MANUAL_ON, OFF, ON
+
+
+class Device(object):
+    TYPE = "device"
+
+    def __init__(self, table_class_name=None):
+        self.device_repository = DeviceRepository(table_class_name)
+        self.edge_server = EdgeServer()
+        self.table_class_name = table_class_name
+
+    def _switch_state(self, command, relay_only=False):
+        return self.edge_server._switch_state(command, relay_only)
+
+    # @property
+    # def relay_state(self):
+    #     # try:
+    #     #     with serial.Serial(cfg.serial.portname, cfg.serial.baudr, timeout=1) as ser_port:
+    #     #         ser_port.write("relay read {}\n\r".format(self.relay_number))
+    #     #         response = ser_port.read(25)
+    #     # except serial.SerialException as e:
+    #     #     logger.error("Serial port error: {}".format(e))
+    #     #     sys.exit(1)
+    #     # else:
+    #     #     if "on" in response:
+    #     #         state = True
+    #     #     elif "off" in response:
+    #     #         state = False
+    #     #     else:
+    #     #         logger.error("Unexpected response: {}".format(response))
+    #     #     return state
+    #     # TODO: edge server
+    #     return False
+
+    def turn_on(self, relay_only=False):
+        self._switch_state("on", relay_only=relay_only)
+
+        if not relay_only and self.TYPE == "boiler":
+            switched_timestamp = datetime.now()
+            self._update_value_in_db(switched_timestamp=switched_timestamp)
+
+    def turn_off(self, relay_only=False):
+        self._switch_state("off", relay_only=relay_only)
+
+        if not relay_only and self.TYPE == "boiler":
+            switched_timestamp = datetime.now()
+            self._update_value_in_db(
+                timestamp=switched_timestamp, switched_timestamp=switched_timestamp
+            )
+
+    def _get_property_from_db(self, *args, **kwargs):
+        return self.device_repository._get_property_from_db(*args, **kwargs)
+
+    def _update_value_in_db(self, **kwargs):
+        return self.device_repository._update_value_in_db(**kwargs)
+
+    def save_status(self):
+        self._update_value_in_db(
+            status=self.status,
+            manual_override=self.manual_override,
+            switched_timestamp=self.switched_timestamp,
+            to_backup=True,
+        )
+
+    def restore_status(self):
+        status, manual_override, switched_timestamp = self._get_property_from_db(
+            "status", "manual_override", "switched_timestamp", from_backup=True
+        )
+        self._update_value_in_db(
+            status=status,
+            manual_override=manual_override,
+            switched_timestamp=switched_timestamp,
+            to_backup=False,
+        )
+
+    @property
+    def timestamp(self):
+        return self._get_property_from_db("timestamp")
+
+    @property
+    def switched_timestamp(self):
+        return self._get_property_from_db("switched_timestamp")
+
+    @property
+    def status(self):
+        return self._get_property_from_db("status")
+
+    @property
+    def manual_override(self):
+        return self._get_property_from_db("manual_override")
+
+    @manual_override.setter
+    def manual_override(self, manual_override):
+        if manual_override == MANUAL_ON:
+            if self.status != ON:
+                self.turn_on()
+            self._update_value_in_db(manual_override=MANUAL_ON)
+        elif manual_override == MANUAL_OFF:
+            if self.status != OFF:
+                self.turn_off()
+            self._update_value_in_db(manual_override=MANUAL_OFF)
+        elif manual_override == MANUAL_AUTO:
+            self._update_value_in_db(manual_override=MANUAL_AUTO)

--- a/dashboard_backend/src/core/services/device.py
+++ b/dashboard_backend/src/core/services/device.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import UTC, datetime
 
 from src.core.repositories.device_repository import DeviceRepository
 from src.core.services.edge_server import EdgeServer
@@ -40,14 +40,14 @@ class Device(object):
         self._switch_state("on", relay_only=relay_only)
 
         if not relay_only and self.TYPE == "boiler":
-            switched_timestamp = datetime.now()
+            switched_timestamp = datetime.now(UTC)
             self._update_value_in_db(switched_timestamp=switched_timestamp)
 
     def turn_off(self, relay_only=False):
         self._switch_state("off", relay_only=relay_only)
 
         if not relay_only and self.TYPE == "boiler":
-            switched_timestamp = datetime.now()
+            switched_timestamp = datetime.now(UTC)
             self._update_value_in_db(
                 timestamp=switched_timestamp, switched_timestamp=switched_timestamp
             )

--- a/dashboard_backend/src/core/services/edge_server.py
+++ b/dashboard_backend/src/core/services/edge_server.py
@@ -112,3 +112,11 @@ class EdgeServer:
         logger.info(f"Edge server response status: {response.status_code}")
         logger.info(f"Edge server response body: {response.text}")
         return self._handle_response(response)
+
+    @catch_connection_error
+    def _switch_state(self, command, relay_only=False):
+        response = requests.post(
+            f"{self.url}/switch_state",
+            json={"command": command, "relay_only": relay_only},
+        )
+        return self._handle_response(response)

--- a/dashboard_backend/src/core/services/edge_server.py
+++ b/dashboard_backend/src/core/services/edge_server.py
@@ -120,3 +120,8 @@ class EdgeServer:
             json={"command": command, "relay_only": relay_only},
         )
         return self._handle_response(response)
+
+    @catch_connection_error
+    def get_all_devices_state(self):
+        response = requests.get(f"{self.url}/get_all_devices_state")
+        return self._handle_response(response)

--- a/dashboard_backend/src/core/services/valve.py
+++ b/dashboard_backend/src/core/services/valve.py
@@ -1,15 +1,26 @@
+from src.core.repositories.device_repository import DeviceRepository
+from src.core.services.device import Device
+from src.core.services.edge_server import EdgeServer
 from src.core.utils.constant import Relay
 
 
-class Valve:
+class Valve(Device):
     def __init__(self, season):
         if season not in ("winter", "summer"):
             raise ValueError("Valve must be winter or summer")
         else:
             self.relay_number = Relay["{}_VALVE".format(season.upper())]
             self.table_class_name = "{}Valve".format(season.capitalize())
+            self.device_repository = DeviceRepository(self.table_class_name)
+            self.edge_server = EdgeServer()
 
     def __getattr__(self, name):
         if name in ("save_status", "restore_status"):
             raise AttributeError("There is no such attribute")
         super(Valve, self).__getattr__(name)
+
+    def turn_on(self, relay_only=False):
+        self._switch_state("on", relay_only=relay_only)
+
+    def turn_off(self, relay_only=False):
+        self._switch_state("off", relay_only=relay_only)

--- a/dashboard_backend/src/core/utils/constant.py
+++ b/dashboard_backend/src/core/utils/constant.py
@@ -7,10 +7,9 @@ WEATHER_URL = "https://barnreportpro.com/api/live_data/tlco"
 WEATHER_HEADERS = {
     "Authorization": "Bearer -_--8-_FLa0Ny995DE__--Hd._L6si4-CB3W-_.O4D_x.UOyP9n-zx_n9sp10H07cC-_.7g-5s96.CJ7tU.E699K8..A8_7-l9hHs._b93_9_.X.v04.5erQbM.-7_6R"
 }
-WINTER, SUMMER, TO_WINTER, TO_SUMMER, FROM_WINTER, FROM_SUMMER = 0, 1, 2, 3, 4, 5
 OFF, ON = 0, 1
 MANUAL_OFF, MANUAL_ON, MANUAL_AUTO = 2, 1, 0
-VALVES_SWITCH_TIME = 2
+VALVES_SWITCH_TIME = 1
 
 EFFICIENCY_HOUR = 12
 
@@ -25,15 +24,6 @@ class ManualState(Enum):
     MANUAL_OFF = 2
     MANUAL_ON = 1
     MANUAL_AUTO = 0
-
-
-class Season(Enum):
-    WINTER = 0
-    SUMMER = 1
-    TO_WINTER = 2
-    TO_SUMMER = 3
-    FROM_WINTER = 4
-    FROM_SUMMER = 5
 
 
 class ValveSwitchTime(Enum):
@@ -52,3 +42,12 @@ class Relay(Enum):
     LED_RED = 8
     LED_GREEN = 9
     LED_BLUE = 10
+
+
+class Mode(Enum):
+    WINTER = 0
+    SUMMER = 1
+    WAITING_SWITCH_TO_WINTER = 2
+    WAITING_SWITCH_TO_SUMMER = 3
+    SWITCHING_TO_WINTER = 4
+    SWITCHING_TO_SUMMER = 5

--- a/dashboard_backend/src/core/utils/constant.py
+++ b/dashboard_backend/src/core/utils/constant.py
@@ -32,10 +32,10 @@ class ValveSwitchTime(Enum):
 
 class Relay(Enum):
     BOILER = 0
-    CHILLER1 = 2
-    CHILLER2 = 1
-    CHILLER3 = 4
-    CHILLER4 = 3
+    CHILLER1 = 1
+    CHILLER2 = 2
+    CHILLER3 = 3
+    CHILLER4 = 4
     WINTER_VALVE = 5
     SUMMER_VALVE = 6
     LED_BREATHER = 7

--- a/dashboard_backend/tests/test_dashboard.py
+++ b/dashboard_backend/tests/test_dashboard.py
@@ -3,192 +3,192 @@ import sys
 from datetime import datetime, timedelta
 
 import pytest
+from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 from unittest.mock import MagicMock
 
-from main import app
+from fastapi import HTTPException
 from src.api.dependencies import get_current_user
-from src.core.common.exceptions import EdgeServerError
+from src.api.routers.dashboard_router import (
+    get_dashboard_service,
+    get_edge_server,
+    router,
+)
+from src.core.common.exceptions import ConnectToEdgeServerError, EdgeServerError
 from src.core.services.chronos import Chronos
+from src.core.services.device import Device
 from src.core.services.edge_server import EdgeServer
 from src.features.auth.jwt_handler import UserToken
 from src.features.dashboard.dashboard_service import DashboardService
 
+app = FastAPI()
+app.include_router(router, prefix="/api")
 
-@pytest.fixture(autouse=True)
-def setup_env():
-    """Set up test environment variables."""
-    os.environ["READ_ONLY_MODE"] = "false"
-    yield
-    # Clean up
-    if "READ_ONLY_MODE" in os.environ:
-        del os.environ["READ_ONLY_MODE"]
+data = {
+    "sensors": {"return_temp": 75.0, "water_out_temp": 85.0},
+    "devices": {"0": True, "1": False, "2": False, "3": False, "4": False},
+    "results": {
+        "outside_temp": 65.0,
+        "baseline_setpoint": 80.0,
+        "setpoint_min": 70.0,
+        "setpoint_max": 110.0,
+    },
+}
 
+settings = {
+    "tolerance": 1.0,
+    "setpoint_min": 75.0,
+    "setpoint_max": 105.0,
+    "cascade_time": 5,
+    "mode_switch_lockout_time": 30,
+    "setpoint_offset_summer": 140,
+    "setpoint_offset_winter": 130,
+    "mode_change_delta_temp": 3,
+}
 
-@pytest.fixture
-def mock_dashboard_service():
-    mock = MagicMock(DashboardService)
-    mock.get_data.return_value = {"key": "value"}
-    mock.get_chart_data.return_value = {"chart_key": "chart_value"}
-    mock.log_generator.return_value = iter(["log_line_1", "log_line_2"])
-    return mock
+settings_invalid = {
+    "setpoint_min": 100,
+    "setpoint_max": 90,
+}
 
-
-@pytest.fixture
-def mock_edge_server(monkeypatch):
-    """Create a dummy edge server for testing."""
-
-    class DummyEdgeServer:
-        def get_temperature_limits(self):
-            return {
-                "hard_limits": {"min_setpoint": 70.0, "max_setpoint": 110.0},
-                "soft_limits": {"min_setpoint": 70.0, "max_setpoint": 110.0},
-            }
-
-        def set_temperature_limits(self, limits: dict):
-            # This will be overridden in specific tests
-            return {"status": "ok"}
-
-        def update_device_state(self, *args, **kwargs):
-            return None
-
-    dummy = DummyEdgeServer()
-    monkeypatch.setattr("src.api.routers.dashboard_router.EdgeServer", lambda: dummy)
-    return dummy
-
-
-@pytest.fixture
-def mock_chronos():
-    mock = MagicMock(Chronos)
-    mock.some_setting = "test"
-    return mock
+switch_season_success_response = {
+    "status": "success",
+    "mode": 0,
+    "mode_switch_timestamp": datetime.now().isoformat(),
+    "mode_switch_lockout_time": 30,
+    "unlock_time": (datetime.now() + timedelta(minutes=30)).isoformat(),
+}
 
 
 @pytest.fixture
 def mock_current_user():
-    return UserToken(user_id="test_user", sub="test_user", email="admin@gmail.com")
+    return UserToken(user_id="test_user", sub="test_user", email="test@example.com")
 
 
 @pytest.fixture
-def client(mock_dashboard_service, mock_edge_server, mock_chronos, mock_current_user):
-    app.dependency_overrides[DashboardService] = lambda: mock_dashboard_service
-    app.dependency_overrides[EdgeServer] = lambda: mock_edge_server
-    app.dependency_overrides[Chronos] = lambda: mock_chronos
-    app.dependency_overrides[get_current_user] = lambda: mock_current_user
-    return TestClient(app)
+def mock_edge_server():
+    mock = MagicMock(spec=EdgeServer)
+    mock.get_temperature_limits.return_value = {
+        "hard_limits": {"min_setpoint": 70.0, "max_setpoint": 110.0},
+        "soft_limits": {"min_setpoint": 70.0, "max_setpoint": 110.0},
+    }
+    mock._switch_state = MagicMock(spec=EdgeServer._switch_state)
+    return mock
 
 
 @pytest.fixture
-def mock_switch_season_response():
-    current_time = datetime.now()
-    unlock_time = current_time + timedelta(minutes=2)
-    return {
-        "message": "Switched to Winter mode successfully",
-        "status": "success",
-        "mode": 0,
-        "mode_switch_timestamp": current_time.isoformat(),
-        "mode_switch_lockout_time": 2,
-        "unlock_time": unlock_time.isoformat(),
+def mock_device():
+    mock = MagicMock(spec=Device)
+    mock.turn_on = MagicMock(spec=Device.turn_on)
+    mock.turn_off = MagicMock(spec=Device.turn_off)
+    mock._switch_state = MagicMock(spec=Device._switch_state)
+    mock.edge_server = MagicMock(spec=EdgeServer)
+    mock.edge_server._switch_state = MagicMock(spec=EdgeServer._switch_state)
+    return mock
+
+
+@pytest.fixture
+def mock_chronos():
+    mock = MagicMock(spec=Chronos)
+    mock.mode = 1
+    mock._save_devices_states = MagicMock(spec=Chronos._save_devices_states)
+    mock.turn_off_devices = MagicMock(spec=Chronos.turn_off_devices)
+
+    return mock
+
+
+@pytest.fixture
+def mock_dashboard_service():
+    mock = MagicMock(spec=DashboardService)
+    mock.switch_season_mode = MagicMock(spec=DashboardService.switch_season_mode)
+    mock.chronos = MagicMock(spec=Chronos)
+    return mock
+
+
+@pytest.fixture
+def client(mock_current_user, mock_edge_server, mock_dashboard_service):
+    app.dependency_overrides = {
+        get_current_user: lambda: mock_current_user,
+        get_edge_server: lambda: mock_edge_server,
+        get_dashboard_service: lambda: mock_dashboard_service,
     }
 
+    with TestClient(app) as test_client:
+        yield test_client
 
-def test_dashboard_data(client):
-    response = client.get("api/")
-    data = response.json()
-    devices = {"0": True, "1": False, "2": False, "3": False, "4": False}
+    app.dependency_overrides.clear()
+
+
+def test_dashboard_data(client, mock_dashboard_service, mock_edge_server):
+    mock_dashboard_service.get_data.return_value = data
+
+    response = client.get("/api/")
 
     assert response.status_code == 200
-    assert "sensors" in data
-    assert "devices" in data
-    assert "results" in data
-    assert "efficiency" in data
-
-    assert "return_temp" in data["sensors"]
-    assert "water_out_temp" in data["sensors"]
-
-    assert devices == data["devices"]
-
-    assert "outside_temp" in data["results"]
-    assert "baseline_setpoint" in data["results"]
-    assert "setpoint_min" in data["results"]
-    assert "setpoint_max" in data["results"]
-
-    assert "average_temperature_difference" in data["efficiency"]
-    assert "chillers_efficiency" in data["efficiency"]
-    assert "hours" in data["efficiency"]
+    assert response.json() == data
 
 
-def test_update_device_state(client):
-    update_data = {"id": 1, "state": "on"}
-    response = client.post("/api/update_device_state", json=update_data)
+def test_update_device_state(client, mock_edge_server):
+    response = client.post("/api/update_device_state", json={"id": 1, "state": True})
     assert response.status_code == 200
     assert response.json() == {"message": "Updated state successfully"}
 
 
-def test_download_log(client):
-    response = client.get("/api/download_log")
-    assert response.status_code == 200
-    content = list(response.iter_lines())
-    assert len(content) >= 1
+def test_update_device_state_error(client, mock_edge_server):
+    mock_edge_server.update_device_state.side_effect = ConnectToEdgeServerError()
+    response = client.post("/api/update_device_state", json={"id": 2, "state": True})
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Could not connect to edge server"}
 
 
-def test_chart_data(client):
-    response = client.get("/api/chart_data")
-    assert response.status_code == 200
-    chart_data = response.json()
-    assert isinstance(chart_data, list)
-    assert all(isinstance(item, dict) and len(item) == 3 for item in chart_data)
-    assert all(
-        "column-1" in item and "column-2" in item and "date" in item
-        for item in chart_data
-    )
-
-
-def test_update_settings(client, mock_edge_server):
-    settings_data = {
-        "tolerance": 1,
-        "setpoint_min": 75,  # Within valid range
-        "setpoint_max": 105,  # Within valid range
-        "setpoint_offset_summer": 140,
-        "setpoint_offset_winter": 130.0,
-        "mode_change_delta_temp": 3,
-        "mode_switch_lockout_time": 30,
-        "cascade_time": 5,
-    }
-
-    # Test successful update
-    response = client.post("/api/update_settings", json=settings_data)
+def test_update_settings_success(client, mock_edge_server):
+    response = client.post("/api/update_settings", json=settings)
     assert response.status_code == 200
     assert response.json() == {"message": "Settings updated successfully"}
 
-    # Test read-only mode error
-    def raise_read_only_error(*args, **kwargs):
-        raise EdgeServerError("Operation not permitted: system is in read-only mode")
 
-    mock_edge_server.set_temperature_limits = raise_read_only_error
-    response = client.post("/api/update_settings", json=settings_data)
+def test_update_settings_temperature_limits_error(client, mock_edge_server):
+    mock_edge_server.set_temperature_limits.side_effect = EdgeServerError("Test error")
+    response = client.post("/api/update_settings", json=settings)
+    assert response.status_code == 400
+    assert response.json() == {
+        "detail": "Failed to update temperature limits: Test error"
+    }
+
+
+def test_update_settings_read_only_mode(client, mock_edge_server):
+    mock_edge_server.set_temperature_limits.side_effect = EdgeServerError(
+        "read-only mode"
+    )
+    response = client.post("/api/update_settings", json=settings)
     assert response.status_code == 403
     assert response.json() == {
         "detail": "Operation not permitted: system is in read-only mode"
     }
 
 
-def test_switch_season(client, mock_dashboard_service, mock_switch_season_response):
-    # Setup mock
-    mock_dashboard_service.switch_season_mode.return_value = mock_switch_season_response
+def test_update_settings_validation(client, mock_edge_server):
+    response = client.post("/api/update_settings", json=settings_invalid)
+    assert response.status_code == 422
 
-    # Test switching to Winter mode
+
+def test_switch_season_success(client, mock_edge_server, mock_dashboard_service):
+    mock_dashboard_service.switch_season_mode.return_value = (
+        switch_season_success_response
+    )
     response = client.post("/api/switch-season", json={"season_value": 0})
+    data = response.json()
     assert response.status_code == 200
-    assert response.json()["status"] == "success"
-    assert response.json()["mode"] == 0
-    assert "unlock_time" in response.json()
-    assert "mode_switch_lockout_time" in response.json()
+    assert data == switch_season_success_response
 
-    # Test invalid season value
-    response = client.post("/api/switch-season", json={"season_value": 3})
+
+def test_switch_season_invalid_season_value(client, mock_dashboard_service):
+    mock_dashboard_service.switch_season_mode.side_effect = HTTPException(
+        status_code=400, detail="Invalid season value: 6"
+    )
+    response = client.post("/api/switch-season", json={"season_value": 6})
     assert response.status_code == 400
     assert "error" in response.json()["status"]
 
@@ -201,7 +201,6 @@ def test_get_data_with_lockout(client, mock_dashboard_service):
             "unlock_time": (current_time + timedelta(minutes=2)).isoformat(),
         }
     }
-    mock_dashboard_service.get_data.return_value = mock_response
 
     response = client.get("/api/")
     assert response.status_code == 200

--- a/dashboard_frontend/src/components/ManualOverride/ManualOverride.jsx
+++ b/dashboard_frontend/src/components/ManualOverride/ManualOverride.jsx
@@ -175,7 +175,7 @@ const ManualOverride = ({ data }) => {
           <div className={`device-control ${isDisabled ? 'disabled' : ''}`}>
             <span className="temp-label">OFF</span>
             <CFormSwitch
-              checked={state[device] === true}
+              checked={state[device].state === 1}
               className="temp-label"
               onChange={(e) =>
                 handleDeviceStateChange(device, e.target.checked)

--- a/dashboard_frontend/src/components/SeasonSwitch/SeasonSwitch.jsx
+++ b/dashboard_frontend/src/components/SeasonSwitch/SeasonSwitch.jsx
@@ -59,6 +59,12 @@ const SeasonSwitch = () => {
       return;
     }
 
+    if (readOnlyMode) {
+      setAlertColor('warning');
+      setAlertMessage('You are in read only mode');
+      return;
+    }
+
     if (isAnimating) return;
 
     try {
@@ -67,14 +73,10 @@ const SeasonSwitch = () => {
       setIsAnimating(true);
 
       await switchSeason(seasonValue);
-
-      setSwitchDirection(null);
-      setIsAnimating(false);
       dispatch(fetchData());
     } catch (error) {
       setSwitchDirection(null);
       setIsAnimating(false);
-      toast.error(error?.message || 'Failed to switch season');
     }
   };
 
@@ -110,8 +112,8 @@ const SeasonSwitch = () => {
             unlockTime && countdown
               ? `Locked - ${countdown} remaining`
               : season === 0
-              ? 'Currently in Winter mode'
-              : 'Switch to Winter mode'
+                ? 'Currently in Winter mode'
+                : 'Switch to Winter mode'
           }
           placement="bottom"
         >
@@ -150,8 +152,8 @@ const SeasonSwitch = () => {
             unlockTime && countdown
               ? `Locked - ${countdown} remaining`
               : season === 1
-              ? 'Currently in Summer mode'
-              : 'Switch to Summer mode'
+                ? 'Currently in Summer mode'
+                : 'Switch to Summer mode'
           }
           placement="bottom"
         >

--- a/dashboard_frontend/src/components/SeasonSwitch/SeasonSwitch.jsx
+++ b/dashboard_frontend/src/components/SeasonSwitch/SeasonSwitch.jsx
@@ -112,8 +112,8 @@ const SeasonSwitch = () => {
             unlockTime && countdown
               ? `Locked - ${countdown} remaining`
               : season === 0
-                ? 'Currently in Winter mode'
-                : 'Switch to Winter mode'
+              ? 'Currently in Winter mode'
+              : 'Switch to Winter mode'
           }
           placement="bottom"
         >
@@ -128,7 +128,7 @@ const SeasonSwitch = () => {
           >
             <img
               src={`/images/Icons/WinterSummer/${
-                season === 0 ? 'WOn' : 'WOff'
+                season === 0 || season === 3 || season === 5 ? 'WOn' : 'WOff'
               }.png`}
               alt="Winter"
               className="season-icon-img"
@@ -137,7 +137,7 @@ const SeasonSwitch = () => {
           </div>
         </CTooltip>
 
-        {season === 0 ? (
+        {season === 0 || season === 3 || season === 5 ? (
           <BsArrowRight
             className={`arrow-icon ${switchDirection ? 'switching' : ''}`}
           />
@@ -152,8 +152,8 @@ const SeasonSwitch = () => {
             unlockTime && countdown
               ? `Locked - ${countdown} remaining`
               : season === 1
-                ? 'Currently in Summer mode'
-                : 'Switch to Summer mode'
+              ? 'Currently in Summer mode'
+              : 'Switch to Summer mode'
           }
           placement="bottom"
         >
@@ -168,7 +168,7 @@ const SeasonSwitch = () => {
           >
             <img
               src={`/images/Icons/WinterSummer/${
-                season === 1 ? 'SOn' : 'SOff'
+                season === 1 || season === 2 || season === 4 ? 'SOn' : 'SOff'
               }.png`}
               alt="Summer"
               className="season-icon-img"

--- a/dashboard_frontend/src/components/__tests__/SystemMap.test.jsx
+++ b/dashboard_frontend/src/components/__tests__/SystemMap.test.jsx
@@ -24,18 +24,37 @@ const mockStore = (state) => {
 describe('SystemMap component', () => {
   const defaultState = {
     manualOverride: {
-      boiler: false,
-      chiller1: false,
-      chiller2: false,
-      chiller3: false,
-      chiller4: false,
+      boiler: {
+        id: 0,
+        state: true,
+        switched_timestamp: '2024-01-01T00:00:00Z',
+      },
+      chiller1: {
+        id: 1,
+        state: false,
+        switched_timestamp: '2024-01-01T00:00:00Z',
+      },
+      chiller2: {
+        id: 2,
+        state: false,
+        switched_timestamp: '2024-01-01T00:00:00Z',
+      },
+      chiller3: {
+        id: 3,
+        state: false,
+        switched_timestamp: '2024-01-01T00:00:00Z',
+      },
+      chiller4: {
+        id: 4,
+        state: false,
+        switched_timestamp: '2024-01-01T00:00:00Z',
+      },
     },
   };
 
   const defaultHomedata = {
     results: { water_out_temp: 50, return_temp: 40 },
     sensors: { water_out_temp: 50, return_temp: 40 },
-    boiler: { some: 'data' },
   };
 
   it('should render summer view with all chillers', () => {
@@ -61,7 +80,11 @@ describe('SystemMap component', () => {
     const overrideState = {
       manualOverride: {
         ...defaultState.manualOverride,
-        boiler: true,
+        boiler: {
+          ...defaultState.manualOverride.boiler,
+          state: 1,
+          switched_timestamp: '2024-01-01T00:00:00Z',
+        },
       },
     };
 
@@ -72,6 +95,7 @@ describe('SystemMap component', () => {
     );
 
     const boilerImage = screen.getByAltText('Boiler');
+
     expect(boilerImage).toHaveAttribute(
       'src',
       'images/Icons/Boiler/Boiler-ON.png',
@@ -82,8 +106,26 @@ describe('SystemMap component', () => {
     const overrideState = {
       manualOverride: {
         ...defaultState.manualOverride,
-        chiller1: true,
-        chiller2: true,
+        chiller1: {
+          ...defaultState.manualOverride.chiller1,
+          state: 1,
+          switched_timestamp: '2024-01-01T00:00:00Z',
+        },
+        chiller2: {
+          ...defaultState.manualOverride.chiller2,
+          state: 1,
+          switched_timestamp: '2024-01-01T00:00:00Z',
+        },
+        chiller3: {
+          ...defaultState.manualOverride.chiller3,
+          state: 0,
+          switched_timestamp: '2024-01-01T00:00:00Z',
+        },
+        chiller4: {
+          ...defaultState.manualOverride.chiller4,
+          state: 0,
+          switched_timestamp: '2024-01-01T00:00:00Z',
+        },
       },
     };
 

--- a/dashboard_frontend/src/components/__tests__/UserSettings.test.jsx
+++ b/dashboard_frontend/src/components/__tests__/UserSettings.test.jsx
@@ -1,6 +1,5 @@
-/* eslint-env jest */
 import React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { Provider } from 'react-redux';
 import { createStore } from 'redux';
 import UserSettings from '../UserSettings/UserSettings';
@@ -24,23 +23,43 @@ jest.mock('../../api/updateBoilerSetpoint', () => ({
 jest.mock('../UserSettings/UserSettings.css', () => {});
 jest.mock('../SeasonSwitch/SeasonSwitch.css', () => {});
 
+jest.mock('../../api/updateSetting', () => ({
+  updateSettings: jest.fn(),
+}));
+
+jest.mock('../../api/updateBoilerSetpoint', () => ({
+  getTemperatureLimits: jest.fn(() =>
+    Promise.resolve({
+      hard_limits: { min_setpoint: 70, max_setpoint: 110 },
+      soft_limits: { min_setpoint: 70, max_setpoint: 110 },
+    }),
+  ),
+}));
+
 const mockStore = (state) => {
   return createStore(() => state);
 };
 
 describe('UserSettings Component', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it('should render user settings component correctly', () => {
     const state = {
       settings: {
         results: {
-          tolerance: 2,
-          setpoint_min: 45,
-          setpoint_max: 85,
-          setpoint_offset_summer: 5,
-          setpoint_offset_winter: 3,
-          mode_change_delta_temp: 4,
-          mode_switch_lockout_time: 30,
-          cascade_time: 15,
+          tolerance: 5,
+          setpoint_min: 75,
+          setpoint_max: 105,
+          setpoint_offset_summer: 0,
+          setpoint_offset_winter: 0,
+          mode_change_delta_temp: 5,
+          mode_switch_lockout_time: 10,
+          cascade_time: 6,
+          baseline_setpoint: 80,
+          tha_setpoint: 85,
+          effective_setpoint: 82,
         },
       },
       chronos: {
@@ -59,15 +78,15 @@ describe('UserSettings Component', () => {
       </Provider>,
     );
 
-    expect(container.querySelector('#tolerance')).toHaveValue(2);
-    expect(container.querySelector('#setpoint_min')).toHaveValue(45);
-    expect(container.querySelector('#setpoint_max')).toHaveValue(85);
-    expect(container.querySelector('#setpoint_offset_summer')).toHaveValue(5);
-    expect(container.querySelector('#mode_change_delta_temp')).toHaveValue(4);
+    expect(container.querySelector('#tolerance')).toHaveValue(5);
+    expect(container.querySelector('#setpoint_min')).toHaveValue(75);
+    expect(container.querySelector('#setpoint_max')).toHaveValue(105);
+    expect(container.querySelector('#setpoint_offset_summer')).toHaveValue(0);
+    expect(container.querySelector('#mode_change_delta_temp')).toHaveValue(5);
     expect(container.querySelector('#mode_switch_lockout_time')).toHaveValue(
-      30,
+      10,
     );
-    expect(container.querySelector('#cascade_time')).toHaveValue(15);
+    expect(container.querySelector('#cascade_time')).toHaveValue(6);
 
     expect(container.querySelector('.update-btn')).toHaveTextContent('Update');
   });
@@ -90,5 +109,159 @@ describe('UserSettings Component', () => {
     );
 
     expect(screen.getByText('Loading user settings...')).toBeInTheDocument();
+  });
+
+  it('should handle input changes correctly', () => {
+    const state = {
+      settings: {
+        results: {
+          tolerance: 5,
+          setpoint_min: 75,
+          setpoint_max: 105,
+        },
+      },
+      chronos: {
+        season: 1,
+        lockoutInfo: null,
+      },
+    };
+
+    const { container } = render(
+      <Provider store={mockStore(state)}>
+        <UserSettings data={state.settings} />
+      </Provider>,
+    );
+
+    const toleranceInput = container.querySelector('#tolerance');
+    fireEvent.change(toleranceInput, {
+      target: { value: '6', name: 'tolerance' },
+    });
+    expect(toleranceInput).toHaveValue(6);
+  });
+
+  it('should show validation error when setpoint_min is greater than setpoint_max', async () => {
+    const state = {
+      settings: {
+        results: {
+          tolerance: 5,
+          setpoint_min: 75,
+          setpoint_max: 105,
+        },
+      },
+      chronos: {
+        season: 1,
+        lockoutInfo: null,
+      },
+    };
+
+    const { container } = render(
+      <Provider store={mockStore(state)}>
+        <UserSettings data={state.settings} />
+      </Provider>,
+    );
+
+    const minInput = container.querySelector('#setpoint_min');
+    const maxInput = container.querySelector('#setpoint_max');
+    const form = container.querySelector('form');
+
+    fireEvent.change(minInput, {
+      target: { value: '100', name: 'setpoint_min' },
+    });
+    fireEvent.change(maxInput, {
+      target: { value: '90', name: 'setpoint_max' },
+    });
+
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    const { toast } = jest.requireMock('react-toastify');
+    expect(toast.error).toHaveBeenCalledWith(
+      'Maximum setpoint must be greater than minimum setpoint',
+    );
+  });
+
+  it('should show validation error when setpoint is outside hard limits', async () => {
+    const state = {
+      settings: {
+        results: {
+          tolerance: 5,
+          setpoint_min: 75,
+          setpoint_max: 105,
+        },
+      },
+      chronos: {
+        season: 1,
+        lockoutInfo: null,
+      },
+    };
+
+    const { container } = render(
+      <Provider store={mockStore(state)}>
+        <UserSettings data={state.settings} />
+      </Provider>,
+    );
+
+    const minInput = container.querySelector('#setpoint_min');
+    const form = container.querySelector('form');
+
+    fireEvent.change(minInput, {
+      target: { value: '60', name: 'setpoint_min' },
+    });
+
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    const { toast } = jest.requireMock('react-toastify');
+    expect(toast.error).toHaveBeenCalledWith(
+      'Minimum setpoint must be between 70°F and 110°F',
+    );
+  });
+
+  it('should show success message on successful update', async () => {
+    const state = {
+      settings: {
+        results: {
+          tolerance: 5,
+          setpoint_min: 75,
+          setpoint_max: 105,
+        },
+      },
+      chronos: {
+        season: 1,
+        lockoutInfo: null,
+      },
+    };
+
+    const { updateSettings } = require('../../api/updateSetting');
+    updateSettings.mockResolvedValueOnce({
+      data: { message: 'Settings updated successfully' },
+    });
+
+    const { container } = render(
+      <Provider store={mockStore(state)}>
+        <UserSettings data={state.settings} />
+      </Provider>,
+    );
+
+    const toleranceInput = container.querySelector('#tolerance');
+    const form = container.querySelector('form');
+
+    fireEvent.change(toleranceInput, {
+      target: { value: '6', name: 'tolerance' },
+    });
+
+    await act(async () => {
+      fireEvent.submit(form);
+    });
+
+    const { toast } = jest.requireMock('react-toastify');
+    expect(updateSettings).toHaveBeenCalledWith(
+      expect.objectContaining({
+        tolerance: 6,
+      }),
+    );
+    expect(toast.success).toHaveBeenCalledWith('Settings updated successfully');
   });
 });

--- a/dashboard_frontend/src/components/systemMap/SystemMap.jsx
+++ b/dashboard_frontend/src/components/systemMap/SystemMap.jsx
@@ -31,7 +31,7 @@ const SystemMap = memo(({ homedata, season, boiler }) => {
                 <div className="position-relative">
                   <img
                     src={
-                      manualOverride.boiler
+                      manualOverride.boiler.state
                         ? 'images/Icons/Boiler/Boiler-ON.png'
                         : 'images/Icons/Boiler/Boiler-OFF.png'
                     }
@@ -135,7 +135,7 @@ const SystemMap = memo(({ homedata, season, boiler }) => {
                   <CCol xs={6} className="d-flex justify-content-end pe-4">
                     <img
                       src={
-                        manualOverride[`chiller1`]
+                        manualOverride[`chiller1`].state
                           ? 'images/Icons/Boiler/Chiller-ON.png'
                           : 'images/Icons/Boiler/Chiller-OFF.png'
                       }
@@ -146,7 +146,7 @@ const SystemMap = memo(({ homedata, season, boiler }) => {
                   <CCol xs={6} className="d-flex justify-content-start ps-4">
                     <img
                       src={
-                        manualOverride[`chiller2`]
+                        manualOverride[`chiller2`].state
                           ? 'images/Icons/Boiler/Chiller-ON.png'
                           : 'images/Icons/Boiler/Chiller-OFF.png'
                       }
@@ -164,7 +164,7 @@ const SystemMap = memo(({ homedata, season, boiler }) => {
                   <CCol xs={6} className="d-flex justify-content-end pe-4">
                     <img
                       src={
-                        manualOverride[`chiller3`]
+                        manualOverride[`chiller3`].state
                           ? 'images/Icons/Boiler/Chiller-ON.png'
                           : 'images/Icons/Boiler/Chiller-OFF.png'
                       }
@@ -175,7 +175,7 @@ const SystemMap = memo(({ homedata, season, boiler }) => {
                   <CCol xs={6} className="d-flex justify-content-start ps-4">
                     <img
                       src={
-                        manualOverride[`chiller4`]
+                        manualOverride[`chiller4`].state
                           ? 'images/Icons/Boiler/Chiller-ON.png'
                           : 'images/Icons/Boiler/Chiller-OFF.png'
                       }

--- a/dashboard_frontend/src/features/chronos/chronosSlice.js
+++ b/dashboard_frontend/src/features/chronos/chronosSlice.js
@@ -52,7 +52,6 @@ export const chronosSlice = createSlice({
         state.status = 'succeeded';
         state.systemStatus = data.status ? 'ONLINE' : 'OFFLINE';
         state.error = null;
-
         state.unlock_time =
           data.results?.unlock_time &&
           new Date(data.results.unlock_time).getTime() > new Date().getTime()

--- a/dashboard_frontend/src/features/chronos/chronosSlice.js
+++ b/dashboard_frontend/src/features/chronos/chronosSlice.js
@@ -42,12 +42,6 @@ export const chronosSlice = createSlice({
         state.season = data.results.mode;
         state.mock_devices = data.mock_devices;
         state.read_only_mode = data.read_only_mode;
-        const unlock_time = new Date(data.results?.unlock_time);
-        if (unlock_time > new Date()) {
-          state.season = data.results.mode === 1 ? 0 : 1;
-        } else {
-          state.season = data.results.mode;
-        }
         state.lastUpdated = new Date().toISOString();
         state.status = 'succeeded';
         state.systemStatus = data.status ? 'ONLINE' : 'OFFLINE';

--- a/edge_server/chronos.log
+++ b/edge_server/chronos.log
@@ -1,0 +1,1640 @@
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 ERROR:Error reading data: Sensor error
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/device_state?device=0 "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/device_state?device=10 "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 403 Forbidden"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 403 Forbidden"
+2025-02-24 14:40:50 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:40:50 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 WARNING:Serial port not accessible ([[Errno 2] could not open port /dev/ttyACM0: [Errno 2] No such file or directory: '/dev/ttyACM0']). Returning mock response for debugging.
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:40:50 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:50 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:50 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:50 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451086224'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:40:50 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451086224'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:40:51 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:40:51 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:51 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:51 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:51 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451523552'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:40:51 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451523552'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:40:52 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451523552'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:40:52 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451523552'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:40:53 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451523552'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:40:53 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451523552'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:40:53 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4451523552'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:Setpoint 60°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:40:53 ERROR:Setpoint 120°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 100.0, 'lead_firing_rate': 100.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 50.0, 'lead_firing_rate': 50.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': False, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': True, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:53 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:40:53 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:53 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:53 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450261312'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:40:53 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450261312'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 71.6, 'inlet_temp': 71.6, 'flue_temp': 71.6}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 89.6, 'outlet_temp': 89.6, 'inlet_temp': 89.6, 'flue_temp': 89.6}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 113.0, 'outlet_temp': 113.0, 'inlet_temp': 113.0, 'flue_temp': 113.0}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 212.0, 'outlet_temp': 212.0, 'inlet_temp': 212.0, 'flue_temp': 212.0}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 14.0, 'outlet_temp': 14.0, 'inlet_temp': 14.0, 'flue_temp': 14.0}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.2, 'outlet_temp': 32.2, 'inlet_temp': 32.2, 'flue_temp': 32.2}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 284.0, 'outlet_temp': 287.6, 'inlet_temp': 280.4, 'flue_temp': 302.0}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 287.6, 'outlet_temp': 291.2, 'inlet_temp': 284.0, 'flue_temp': 305.6}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 291.2, 'outlet_temp': 294.8, 'inlet_temp': 287.6, 'flue_temp': 309.2}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 294.8, 'outlet_temp': 298.4, 'inlet_temp': 291.2, 'flue_temp': 312.8}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 298.4, 'outlet_temp': 302.0, 'inlet_temp': 294.8, 'flue_temp': 316.4}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:40:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:40:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:40:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:40:55 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:40:55 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:40:57 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:40:57 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:41:00 ERROR:Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:41:00 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:41:01 INFO:Successfully read boiler data (attempt 3)
+2025-02-24 14:41:01 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:01 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:01 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:01 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:41:01 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:01 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:01 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:01 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:02 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:02 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:03 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:03 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:03 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:03 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:03 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:04 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:04 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:05 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:05 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:05 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:05 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:41:05 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:06 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:41:06 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:07 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:41:07 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:07 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:07 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:07 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:07 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:07 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:07 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:07 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:07 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:07 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:07 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:07 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:07 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:07 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:07 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450658896'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:07 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450658896'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:08 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450658896'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:08 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450658896'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:09 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450658896'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:09 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450658896'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:09 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4450658896'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 ERROR:Error reading data: Sensor error
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/device_state?device=0 "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/device_state?device=10 "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 403 Forbidden"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 403 Forbidden"
+2025-02-24 14:41:33 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:33 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 WARNING:Serial port not accessible ([[Errno 2] could not open port /dev/ttyACM0: [Errno 2] No such file or directory: '/dev/ttyACM0']). Returning mock response for debugging.
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:41:33 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:33 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:33 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:33 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:33 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440155744'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:41:33 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440155744'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:41:34 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:41:34 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:34 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:34 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:34 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440806064'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:34 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440806064'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:35 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440806064'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:35 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440806064'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:36 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440806064'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:36 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440806064'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:36 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440806064'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:Setpoint 60°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:41:36 ERROR:Setpoint 120°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 100.0, 'lead_firing_rate': 100.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 50.0, 'lead_firing_rate': 50.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': False, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': True, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:36 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:41:36 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:36 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:36 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440809088'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:41:36 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440809088'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 71.6, 'inlet_temp': 71.6, 'flue_temp': 71.6}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 89.6, 'outlet_temp': 89.6, 'inlet_temp': 89.6, 'flue_temp': 89.6}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 113.0, 'outlet_temp': 113.0, 'inlet_temp': 113.0, 'flue_temp': 113.0}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 212.0, 'outlet_temp': 212.0, 'inlet_temp': 212.0, 'flue_temp': 212.0}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 14.0, 'outlet_temp': 14.0, 'inlet_temp': 14.0, 'flue_temp': 14.0}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.2, 'outlet_temp': 32.2, 'inlet_temp': 32.2, 'flue_temp': 32.2}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 284.0, 'outlet_temp': 287.6, 'inlet_temp': 280.4, 'flue_temp': 302.0}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 287.6, 'outlet_temp': 291.2, 'inlet_temp': 284.0, 'flue_temp': 305.6}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 291.2, 'outlet_temp': 294.8, 'inlet_temp': 287.6, 'flue_temp': 309.2}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 294.8, 'outlet_temp': 298.4, 'inlet_temp': 291.2, 'flue_temp': 312.8}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 298.4, 'outlet_temp': 302.0, 'inlet_temp': 294.8, 'flue_temp': 316.4}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:41:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:37 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:39 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:41:39 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:41:42 ERROR:Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:41:42 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:41:44 INFO:Successfully read boiler data (attempt 3)
+2025-02-24 14:41:44 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:44 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:44 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:44 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:41:44 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:44 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:44 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:44 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:45 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:45 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:46 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:46 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:46 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:41:46 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:46 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:47 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:47 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:48 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:48 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:48 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:41:48 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:41:48 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:49 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:41:49 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:50 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:41:50 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:50 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:41:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:50 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:50 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:50 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:50 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:50 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:50 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:50 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440812112'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:50 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440812112'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:51 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440812112'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:51 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440812112'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:52 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440812112'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:52 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440812112'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:52 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4440812112'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 ERROR:Error reading data: Sensor error
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/device_state?device=0 "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/device_state?device=10 "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 403 Forbidden"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 403 Forbidden"
+2025-02-24 14:41:56 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:41:56 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 WARNING:Serial port not accessible ([[Errno 2] could not open port /dev/ttyACM0: [Errno 2] No such file or directory: '/dev/ttyACM0']). Returning mock response for debugging.
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:41:56 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:56 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:56 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:56 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:56 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378353280'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:41:56 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378353280'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:41:57 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:41:57 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:57 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:57 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:57 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378790608'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:57 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378790608'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:58 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378790608'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:58 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378790608'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:59 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378790608'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:59 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378790608'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:59 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4378790608'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:Setpoint 60°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:41:59 ERROR:Setpoint 120°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 100.0, 'lead_firing_rate': 100.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 50.0, 'lead_firing_rate': 50.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': False, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': True, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:41:59 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:41:59 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:41:59 WARNING:Unable to connect to Modbus device
+2025-02-24 14:41:59 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4375902400'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:41:59 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4375902400'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 71.6, 'inlet_temp': 71.6, 'flue_temp': 71.6}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 89.6, 'outlet_temp': 89.6, 'inlet_temp': 89.6, 'flue_temp': 89.6}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 113.0, 'outlet_temp': 113.0, 'inlet_temp': 113.0, 'flue_temp': 113.0}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 212.0, 'outlet_temp': 212.0, 'inlet_temp': 212.0, 'flue_temp': 212.0}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 14.0, 'outlet_temp': 14.0, 'inlet_temp': 14.0, 'flue_temp': 14.0}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.2, 'outlet_temp': 32.2, 'inlet_temp': 32.2, 'flue_temp': 32.2}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 284.0, 'outlet_temp': 287.6, 'inlet_temp': 280.4, 'flue_temp': 302.0}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 287.6, 'outlet_temp': 291.2, 'inlet_temp': 284.0, 'flue_temp': 305.6}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 291.2, 'outlet_temp': 294.8, 'inlet_temp': 287.6, 'flue_temp': 309.2}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 294.8, 'outlet_temp': 298.4, 'inlet_temp': 291.2, 'flue_temp': 312.8}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 298.4, 'outlet_temp': 302.0, 'inlet_temp': 294.8, 'flue_temp': 316.4}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:42:00 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:00 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:42:00 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:00 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:01 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:01 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:03 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:03 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:06 ERROR:Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:06 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:07 INFO:Successfully read boiler data (attempt 3)
+2025-02-24 14:42:07 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:07 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:07 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:07 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:42:07 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:07 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:07 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:07 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:08 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:08 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:09 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:09 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:09 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:09 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:09 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:10 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:10 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:11 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:11 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:11 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:11 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:42:11 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:12 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:42:12 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:13 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:42:13 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:13 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:13 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:13 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:13 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:13 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:13 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:13 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:13 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:13 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:13 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:13 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:13 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:13 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:13 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4379240368'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:13 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4379240368'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:14 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4379240368'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:14 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4379240368'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:15 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4379240368'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:15 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4379240368'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:15 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4379240368'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 ERROR:Error reading data: Sensor error
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/get_data "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/device_state?device=0 "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/device_state?device=10 "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/device_state "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/download_log "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 500 Internal Server Error"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 503 Service Unavailable"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_stats "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/boiler_status "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 429 Too Many Requests"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 422 Unprocessable Entity"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/boiler_set_setpoint "HTTP/1.1 403 Forbidden"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: POST http://testserver/temperature_limits "HTTP/1.1 403 Forbidden"
+2025-02-24 14:42:37 DEBUG:Using selector: KqueueSelector
+2025-02-24 14:42:37 INFO:HTTP Request: GET http://testserver/temperature_limits "HTTP/1.1 200 OK"
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 WARNING:Serial port not accessible ([[Errno 2] could not open port /dev/ttyACM0: [Errno 2] No such file or directory: '/dev/ttyACM0']). Returning mock response for debugging.
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:42:37 WARNING:Serial port not accessible ([Serial not accessible]). Returning mock response for debugging.
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:37 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:37 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:37 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:37 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373015792'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:42:37 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373015792'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:42:38 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:42:38 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:38 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:38 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:38 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373387584'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:38 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373387584'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:39 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373387584'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:39 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373387584'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:40 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373387584'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:40 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373387584'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:40 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4373387584'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:Setpoint 60°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:42:40 ERROR:Setpoint 120°F is out of valid range (70.0-110.0°F)
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 100.0, 'lead_firing_rate': 100.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 50.0, 'lead_firing_rate': 50.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': False, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': False, 'pump_status': True, 'flame_status': False, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:40 DEBUG:Boiler stats: {'operating_mode': 0, 'operating_mode_str': 'Initialization', 'cascade_mode': 0, 'cascade_mode_str': 'Single Boiler', 'current_setpoint': 32.0, 'min_setpoint': 32.0, 'max_setpoint': 32.0, 'alarm_status': False, 'pump_status': False, 'flame_status': False, 'cascade_current_power': 0.0, 'lead_firing_rate': 0.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:42:40 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:40 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:40 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371852864'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:42:40 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371852864'>: Modbus Error: [Input/Output] First attempt fails
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 2)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 1, 'operating_mode_str': 'Standby', 'cascade_mode': 2, 'cascade_mode_str': 'Member', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 71.6, 'inlet_temp': 71.6, 'flue_temp': 71.6}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 89.6, 'outlet_temp': 89.6, 'inlet_temp': 89.6, 'flue_temp': 89.6}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 113.0, 'outlet_temp': 113.0, 'inlet_temp': 113.0, 'flue_temp': 113.0}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.0, 'outlet_temp': 32.0, 'inlet_temp': 32.0, 'flue_temp': 32.0}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 212.0, 'outlet_temp': 212.0, 'inlet_temp': 212.0, 'flue_temp': 212.0}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 14.0, 'outlet_temp': 14.0, 'inlet_temp': 14.0, 'flue_temp': 14.0}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 32.2, 'outlet_temp': 32.2, 'inlet_temp': 32.2, 'flue_temp': 32.2}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 284.0, 'outlet_temp': 287.6, 'inlet_temp': 280.4, 'flue_temp': 302.0}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 287.6, 'outlet_temp': 291.2, 'inlet_temp': 284.0, 'flue_temp': 305.6}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 291.2, 'outlet_temp': 294.8, 'inlet_temp': 287.6, 'flue_temp': 309.2}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 294.8, 'outlet_temp': 298.4, 'inlet_temp': 291.2, 'flue_temp': 312.8}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 298.4, 'outlet_temp': 302.0, 'inlet_temp': 294.8, 'flue_temp': 316.4}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 300.2, 'outlet_temp': 303.8, 'inlet_temp': 296.6, 'flue_temp': 318.2}
+2025-02-24 14:42:41 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:41 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 302.0, 'outlet_temp': 305.6, 'inlet_temp': 298.4, 'flue_temp': 320.0}
+2025-02-24 14:42:41 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:41 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:42 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:42 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:44 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:44 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:47 ERROR:Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:47 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read input register 3: Modbus Error: [Input/Output] Timeout
+2025-02-24 14:42:48 INFO:Successfully read boiler data (attempt 3)
+2025-02-24 14:42:48 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:48 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:48 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:48 INFO:Successfully set boiler setpoint to 90°F (54%)
+2025-02-24 14:42:48 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:48 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:48 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:48 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:49 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:49 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:50 ERROR:Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:50 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:50 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Modbus Error: [Input/Output] Connection lost
+2025-02-24 14:42:50 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:50 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:51 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:51 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:52 ERROR:Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:52 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:52 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: Invalid CRC
+2025-02-24 14:42:52 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:42:52 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:53 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:42:53 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:54 ERROR:Failed to read holding register 0: No response
+2025-02-24 14:42:54 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:54 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register 0: No response
+2025-02-24 14:42:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:54 INFO:Successfully read boiler data (attempt 1)
+2025-02-24 14:42:54 DEBUG:Boiler stats: {'operating_mode': 2, 'operating_mode_str': 'CH Demand', 'cascade_mode': 1, 'cascade_mode_str': 'Manager', 'current_setpoint': 59.0, 'min_setpoint': 53.6, 'max_setpoint': 64.4, 'alarm_status': True, 'pump_status': True, 'flame_status': True, 'cascade_current_power': 86.0, 'lead_firing_rate': 66.0, 'system_supply_temp': 71.6, 'outlet_temp': 64.4, 'inlet_temp': 60.8, 'flue_temp': 68.0}
+2025-02-24 14:42:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:54 ERROR:[Errno 2] could not open port /dev/ttyUSB0: [Errno 2] No such file or directory: '/dev/ttyUSB0'
+2025-02-24 14:42:54 WARNING:Unable to connect to Modbus device
+2025-02-24 14:42:54 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371850848'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:54 ERROR:Failed to read boiler data (attempt 1): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371850848'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:55 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371850848'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:55 ERROR:Failed to read boiler data (attempt 2): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371850848'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:56 ERROR:Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371850848'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:56 ERROR:Failed to read boiler data (attempt 3): Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371850848'>: Modbus Error: [Input/Output] Communication failed
+2025-02-24 14:42:56 ERROR:Failed to read boiler data after 3 attempts: Modbus Error: Failed to read holding register <MagicMock name='cfg.registers.holding.operating_mode' id='4371850848'>: Modbus Error: [Input/Output] Communication failed

--- a/edge_server/chronos/app.py
+++ b/edge_server/chronos/app.py
@@ -23,7 +23,6 @@ from chronos.devices import (
 )
 from chronos.mock_devices.mock_data import (
     mock_boiler_stats,
-    mock_devices_data,
     mock_operating_status,
     mock_point_update,
     mock_sensors,
@@ -185,11 +184,9 @@ async def get_data():
     if MOCK_DEVICES:
         try:
             sensors = mock_sensors()
-            devices = {device["id"]: device["state"] for device in mock_devices_data()}
             status = True
             return SystemStatus(
                 sensors=sensors,
-                devices=devices,
                 status=status,
                 mock_devices=MOCK_DEVICES,
                 read_only_mode=cfg.READ_ONLY_MODE,
@@ -198,7 +195,6 @@ async def get_data():
             logger.error(f"Error reading data: {e}")
             return SystemStatus(
                 sensors={},
-                devices={},
                 status=False,
                 mock_devices=True,
                 read_only_mode=cfg.READ_ONLY_MODE,
@@ -238,6 +234,15 @@ async def switch_state(data: SwitchStateRequest):
         return True
     """Switch state of a device."""
     return DEVICES[0].switch_state(data.command, data.relay_only)
+
+
+@app.get("/get_all_devices_state", response_model=list[DeviceModel])
+@with_circuit_breaker
+async def get_all_devices_state():
+    if MOCK_DEVICES:
+        return [DeviceModel(id=i, state=True) for i in range(5)]
+
+    return [DeviceModel(id=i, state=DEVICES[i].state) for i in range(5)]
 
 
 @app.get("/device_state", response_model=DeviceModel)

--- a/edge_server/chronos/app.py
+++ b/edge_server/chronos/app.py
@@ -12,6 +12,7 @@ from chronos.data_models import (
     OperatingStatus,
     SetpointLimitsUpdate,
     SetpointUpdate,
+    SwitchStateRequest,
     SystemStatus,
 )
 from chronos.devices import (
@@ -226,6 +227,17 @@ async def get_data():
             mock_devices=False,
             read_only_mode=cfg.READ_ONLY_MODE,
         )
+
+
+@app.post("/switch_state")
+# @with_circuit_breaker
+# @with_rate_limit
+# @check_read_only
+async def switch_state(data: SwitchStateRequest):
+    if MOCK_DEVICES:
+        return True
+    """Switch state of a device."""
+    return DEVICES[0].switch_state(data.command, data.relay_only)
 
 
 @app.get("/device_state", response_model=DeviceModel)

--- a/edge_server/chronos/data_models.py
+++ b/edge_server/chronos/data_models.py
@@ -13,6 +13,11 @@ class SystemStatus(BaseModel):
     read_only_mode: bool = False
 
 
+class SwitchStateRequest(BaseModel):
+    command: str
+    relay_only: bool = False
+
+
 class DeviceModel(BaseModel):
     id: int = Field(..., ge=0, lt=7, description="Device ID (0-4)")
     state: bool

--- a/edge_server/chronos/data_models.py
+++ b/edge_server/chronos/data_models.py
@@ -7,7 +7,6 @@ from .config import cfg
 
 class SystemStatus(BaseModel):
     sensors: dict
-    devices: dict
     status: bool
     mock_devices: bool = False
     read_only_mode: bool = False

--- a/edge_server/tests/test_app.py
+++ b/edge_server/tests/test_app.py
@@ -48,13 +48,9 @@ def test_get_data(client, mock_temperature_sensor, mock_serial_devices):
     data = response.json()
 
     assert "sensors" in data
-    assert "devices" in data
     assert isinstance(data["sensors"]["water_out_temp"], (int, float))
     assert isinstance(data["sensors"]["return_temp"], (int, float))
     assert data["mock_devices"] in [True, False]
-    assert isinstance(data["devices"], dict)
-    for key, value in data["devices"].items():
-        assert value in [True, False]
 
 
 def test_get_data_with_sensor_error(
@@ -68,11 +64,8 @@ def test_get_data_with_sensor_error(
         assert response.status_code == 200
 
         data = response.json()
-        print("data", data)
-        assert isinstance(data["sensors"], dict)
         assert isinstance(data["sensors"], dict)
         assert data["status"] is False
-        assert isinstance(data["devices"], dict)
 
 
 def test_get_device_state(client, mock_serial_devices):


### PR DESCRIPTION
#62 
- Get relay status, switched_time that saved to DB to the UI 
- When user switch the relay (boiler, chiller), we will tracking status and switched_time to DB 
- The logic when switch season, we will: (based on old logic https://github.com/leej3/chronos2/pull/49#discussion_r1955910437) 

 ```
       1. Change mode to WAITING_SWITCH_TO_WINTER or WAITING_SWITCH_TO_SUMMER:
            - Turn off all devices
            - Turn on/off valves (summer or winter)
            - Add job to switch season after <mode_switch_lockout_time> minutes. <mode_switch_lockout_time> will be set in user's setting
        2. Run the cron job to switch season after <mode_switch_lockout_time> minutes:
            - Restore devices states
            - Switch devices
            - Change mode to SUMMER or WINTER
```