### PR TITLE
Fixing windows deployment

### DIFF
--- a/setup-dotenv.bat
+++ b/setup-dotenv.bat
@@ -1,0 +1,24 @@
+@echo off
+setlocal enabledelayedexpansion
+
+REM Copy all .env.sample files to .env.docker
+for /r %%f in (*.env.sample) do (
+    set "src=%%f"
+    set "dest=%%f"
+    set "dest=!dest:.sample=.docker!"
+    copy "!src!" "!dest!" >nul
+    echo Copied !src! to !dest!
+)
+
+REM Copy all .env.sample.local files to .env
+for /r %%f in (*.env.sample.local) do (
+    set "src=%%f"
+    set "dest=%%f"
+    set "dest=!dest:.sample.local=!"
+    copy "!src!" "!dest!" >nul
+    echo Copied !src! to !dest!
+)
+
+endlocal
+
+docker compose up --build


### PR DESCRIPTION
Fixes #92 
For windows ecosystem, we need a `.bat` file, which is equivalent to `.sh` file on linux/unix systems. This PR adds that for env setup. Now to run on windows for local development just do 

```
.\setup-dotenv.bat    
```
Screenshots of final result: 

On Chrome : 

<img width="941" alt="image" src="https://github.com/user-attachments/assets/5edd5df7-ab31-4980-a229-5e2ebbbffd88" />


On Edge:

<img width="952" alt="image" src="https://github.com/user-attachments/assets/5493137f-8747-4417-b621-f568b4358790" />

We can also add a note in Readme.

